### PR TITLE
feat: add goreleaser v1.21.2 to go-builder image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Builds and publishes a Go builder container image (`ghcr.io/bradfordwagner/go-builder`) using a bespoke native Docker pipeline. The image is an Ansible-provisioned base with Go installed, produced across a three-axis matrix: `os × arch × go_version`.
+Builds and publishes a Go builder container image (`ghcr.io/bradfordwagner/go-builder`) using a bespoke native Docker pipeline. The image is an Ansible-provisioned base with Go and goreleaser installed, produced across a three-axis matrix: `os × arch × go_version`.
 
 ## Key Files
 
@@ -11,8 +11,8 @@ Builds and publishes a Go builder container image (`ghcr.io/bradfordwagner/go-bu
 | `config.yaml` | Single source of truth for the full build matrix |
 | `Dockerfile` | Multi-stage build: ansible upstream → lean runtime base |
 | `scripts/matrix.py` | Reads `config.yaml`, emits JSON for GitHub Actions matrix strategy |
-| `requirements.yml` | Ansible Galaxy role pin (`bradfordwagner.golang`) |
-| `playbook.yml` | Ansible playbook that installs Go |
+| `requirements.yml` | Ansible Galaxy role pins (`bradfordwagner.golang`, `andrewrothstein.goreleaser`) |
+| `playbook.yml` | Ansible playbook that installs Go and goreleaser |
 | `.github/workflows/container_branches.yml` | Branch build workflow; push gated by `push_enabled` |
 | `.github/workflows/daily_build.yml` | Daily cron (8am EST); always pushes regardless of `push_enabled` |
 
@@ -87,6 +87,7 @@ Multi-stage: first stage uses the OS-specific ansible image to run the Ansible p
 - **Upstream ansible image**: update `upstream.tag`
 - **Runtime base image**: update `runtime.tag`
 - **Ansible golang role**: update `version` in `requirements.yml`
+- **goreleaser version**: update `goreleaser_version` in `playbook.yml` and the table in `README.md`
 
 ## Testing a Build Locally
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /src
 
 RUN ansible-galaxy install -r requirements.yml \
  && ansible-playbook playbook.yml -e go_version=${GO_VERSION} \
+ && goreleaser --version \
  && rm -rf /src
 
 FROM ${RUNTIME}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # container-go-builder
 Image build for https://quay.io/repository/bradfordwagner/go-builder?tab=tags
+
+Ansible-provisioned builder image with Go and goreleaser installed, built across a matrix of OS × arch × go_version.
+
+## Installed Tools
+
+| Tool | Version |
+|------|---------|
+| Go | see `go_versions` in `config.yaml` |
+| goreleaser | v1.21.2 |

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 target_repo: ghcr.io/bradfordwagner/go-builder
-push_enabled: true
+push_enabled: false
 
 go_versions:
   - "1.25"

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ upstream:
 
 runtime:
   image: ghcr.io/bradfordwagner/base
-  tag: 4.4.0
+  tag: 4.5.0
 
 builds:
   - os: ubuntu_noble

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 target_repo: ghcr.io/bradfordwagner/go-builder
-push_enabled: false
+push_enabled: true
 
 go_versions:
   - "1.25"

--- a/openspec/changes/add-goreleaser/.openspec.yaml
+++ b/openspec/changes/add-goreleaser/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/add-goreleaser/design.md
+++ b/openspec/changes/add-goreleaser/design.md
@@ -1,0 +1,32 @@
+## Context
+
+The go-builder image currently installs Go via the `bradfordwagner.golang` Ansible role. Downstream pipelines that need goreleaser must install it themselves, adding per-job overhead and introducing version drift across repos. Bundling goreleaser into the builder image centralizes version control and eliminates per-job install steps.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Install goreleaser at a pinned version into all build matrix variants
+- Verify the binary with a checksum from the role's built-in map
+- No additional roles required in `requirements.yml` beyond `andrewrothstein.goreleaser`
+
+**Non-Goals:**
+- Goreleaser configuration or `.goreleaser.yaml` templating
+- Upgrading goreleaser automatically (version is explicitly pinned)
+- Installing goreleaser Pro
+
+## Decisions
+
+**Use `andrewrothstein.goreleaser` over a shell task**
+The role handles cross-platform arch mapping, checksum verification, and download URL construction. A raw `get_url` + `unarchive` task would replicate this logic. The role pulls in `andrewrothstein.unarchivedeps` as a transitive dependency (ensures `tar`/`unzip` are present) and is actively maintained (v2.2.47, April 2025).
+
+**Pin goreleaser to v1.21.2**
+v1.21.2 is present in the role's built-in checksum map for `Linux_x86_64` and `Linux_arm64`, matching both target arches. This version is compatible with the downstream pipelines that will consume this image.
+
+**Apply goreleaser role after `bradfordwagner.golang`**
+Ordering is cosmetic (goreleaser is a standalone binary), but placing it after Go signals intent: this is a Go toolchain image.
+
+## Risks / Trade-offs
+
+- [Version staleness] → goreleaser v1.21.2 is ~2 major versions behind v2.x. Downstream consumers must not rely on v2-only features. Mitigation: version is explicitly documented in `README.md` and `playbook.yml`.
+- [Image size] → goreleaser binary adds ~50MB to the image. Mitigation: acceptable for a builder image; no runtime containers consume this image.
+- [Checksum coverage] → if a future goreleaser version is not in the role's checksum map, the install will fail or skip verification. Mitigation: always pick a version present in `defaults/main.yml` of the pinned role version.

--- a/openspec/changes/add-goreleaser/proposal.md
+++ b/openspec/changes/add-goreleaser/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The go-builder image is used as a CI/CD build environment. Adding goreleaser brings release automation tooling into the image so downstream pipelines can produce tagged releases without installing goreleaser separately at runtime.
+
+## What Changes
+
+- Add `andrewrothstein.goreleaser` Ansible Galaxy role to `requirements.yml` (pinned to `v2.2.47`)
+- Set `goreleaser_version: v1.21.2` in `playbook.yml` and apply the role after `bradfordwagner.golang`
+- Update `README.md` with an installed tools table listing goreleaser version
+- Update `AGENTS.md` to reflect goreleaser in the project overview, key files table, and bumping dependencies section
+
+## Capabilities
+
+### New Capabilities
+
+- `goreleaser-install`: Install goreleaser into the builder image via the `andrewrothstein.goreleaser` Ansible role, pinned to a specific version
+
+### Modified Capabilities
+
+<!-- No existing spec-level requirements are changing -->
+
+## Impact
+
+- `requirements.yml`: new role dependency
+- `playbook.yml`: new role invocation + version var
+- All build matrix variants (ubuntu_noble, debian_bookworm-slim × linux/amd64, linux/arm64 × Go 1.25, 1.26) now include goreleaser in the output image
+- Image size increases by the goreleaser binary (~50MB compressed)

--- a/openspec/changes/add-goreleaser/specs/goreleaser-install/spec.md
+++ b/openspec/changes/add-goreleaser/specs/goreleaser-install/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: goreleaser is installed in the builder image
+The builder image SHALL include the goreleaser binary at a pinned version via the `andrewrothstein.goreleaser` Ansible role.
+
+#### Scenario: Binary is present after build
+- **WHEN** the builder image is built for any supported os × arch combination
+- **THEN** `goreleaser --version` exits 0 and reports the pinned version
+
+#### Scenario: Version is pinned
+- **WHEN** `goreleaser_version` is set in `playbook.yml`
+- **THEN** the installed binary matches that exact version
+
+### Requirement: goreleaser role is declared in requirements
+The `requirements.yml` file SHALL declare `andrewrothstein.goreleaser` at a pinned role version so `ansible-galaxy` can install it reproducibly.
+
+#### Scenario: Role installs without error
+- **WHEN** `ansible-galaxy install -r requirements.yml` is executed
+- **THEN** the `andrewrothstein.goreleaser` role is installed with no errors
+
+### Requirement: goreleaser version is documented in README
+The `README.md` SHALL include a table listing the installed goreleaser version so consumers know what version they get.
+
+#### Scenario: Table is present
+- **WHEN** a developer reads `README.md`
+- **THEN** they can find the goreleaser version in the installed tools table without inspecting playbook files

--- a/openspec/changes/add-goreleaser/tasks.md
+++ b/openspec/changes/add-goreleaser/tasks.md
@@ -1,0 +1,17 @@
+## 1. Ansible Role Setup
+
+- [ ] 1.1 Add `andrewrothstein.goreleaser` at role version `v2.2.47` to `requirements.yml`
+- [ ] 1.2 Set `goreleaser_version: v1.21.2` in `playbook.yml` vars
+- [ ] 1.3 Add `andrewrothstein.goreleaser` role to `playbook.yml` roles list (after `bradfordwagner.golang`)
+
+## 2. Documentation
+
+- [ ] 2.1 Add installed tools table to `README.md` listing goreleaser v1.21.2
+- [ ] 2.2 Update `AGENTS.md` project overview to mention goreleaser
+- [ ] 2.3 Update `AGENTS.md` key files table for `requirements.yml` and `playbook.yml` entries
+- [ ] 2.4 Update `AGENTS.md` bumping dependencies section with goreleaser version instructions
+
+## 3. Verification
+
+- [ ] 3.1 Push feature branch and confirm all 8 matrix build jobs pass (ubuntu_noble + debian_bookworm-slim × amd64 + arm64 × Go 1.25 + 1.26)
+- [ ] 3.2 Pull a built image locally and run `docker run --rm <image> goreleaser --version` to confirm the binary is present and reports v1.21.2

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,5 +2,7 @@
 - hosts: localhost
   vars:
     go_src_cleanup_enabled: false
+    goreleaser_version: v1.21.2
   roles:
     - role: bradfordwagner.golang
+    - role: andrewrothstein.goreleaser

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,5 @@
 ---
 - role: bradfordwagner.golang
   version: 1.0.3
+- role: andrewrothstein.goreleaser
+  version: v2.2.47


### PR DESCRIPTION
## Summary

- Add `andrewrothstein.goreleaser` role (v2.2.47) to `requirements.yml`, pinned to goreleaser v1.21.2
- Add `goreleaser --version` verification step in Dockerfile build stage
- Bump runtime base to `4.5.0` (which adds git to all OS variants)
- Update README with installed tools table, AGENTS.md with goreleaser references

## Test plan

- [x] All 8 matrix build jobs passed (ubuntu_noble + debian_bookworm-slim × amd64 + arm64 × Go 1.25 + 1.26)
- [x] All 4 manifest jobs passed
- [x] `goreleaser --version` confirmed v1.21.2 on linux/arm64 locally
- [x] Push enabled — images published to ghcr.io